### PR TITLE
add \n to the function: tokenize_text

### DIFF
--- a/generate_vectors.py
+++ b/generate_vectors.py
@@ -126,7 +126,7 @@ def tokenize_text(input_filename, output_filename):
                 else:
                     tokenized_text = ' '.join(tinysegmenter.tokenize(text))
 
-                out.write(tokenized_text)
+                out.write(tokenized_text + '\n')
 
                 if i % 100 == 0 and i != 0:
                     logging.info('Tokenized {} articles.'.format(i))


### PR DESCRIPTION
I think there is need to add '\n' at line 129 => out.write(tokenized_text + '\n')
Without adding '\n', the further Word2vec module cannot work.